### PR TITLE
[Fix]cat-img-api/config/initializers/cors.rb  origins 変更

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins "web.judging-cats.com","api.judging-cats.com"
+    origins "localhost:3001","web.judging-cats.com"
 
     resource "*",
       headers: :any,


### PR DESCRIPTION
[理由]異オリジンじゃないのが含まれていたため